### PR TITLE
feat: removing anniversary date rule

### DIFF
--- a/fincore.py
+++ b/fincore.py
@@ -2759,9 +2759,6 @@ def preprocess_bullet(
     if anniversary_date and anniversary_date <= zero_date:
         raise ValueError(f'the "anniversary_date", {anniversary_date}, must be greater than "zero_date", {zero_date}')
 
-    elif anniversary_date and abs((anniversary_date - (zero_date + _MONTH * term)).days) > 20:
-        raise ValueError(f'the "anniversary_date", {anniversary_date}, is more than 20 days away from the regular payment date, {zero_date + _MONTH * term}')
-
     for i, x in enumerate(insertions):
         if x.value <= 0:
             raise ValueError(f'invalid value for insertion entry #{i} – should be positive')
@@ -2829,9 +2826,6 @@ def preprocess_jm(
 
     if anniversary_date and anniversary_date <= zero_date:
         raise ValueError(f'the "anniversary_date", {anniversary_date}, must be greater than "zero_date", {zero_date}')
-
-    elif anniversary_date and abs((anniversary_date - (zero_date + _MONTH)).days) > 20:
-        raise ValueError(f'the "anniversary_date", {anniversary_date}, is more than 20 days away from the regular payment date, {zero_date + _MONTH}')
 
     if vir and vir.code == 'Poupança':
         raise NotImplementedError('"Poupança" is currently unsupported')  # pragma: no cover
@@ -2933,9 +2927,6 @@ def preprocess_price(
     if anniversary_date and anniversary_date <= zero_date:
         raise ValueError(f'the "anniversary_date", {anniversary_date}, must be greater than "zero_date", {zero_date}')
 
-    elif anniversary_date and abs((anniversary_date - (zero_date + _MONTH)).days) > 20:
-        raise ValueError(f'the "anniversary_date", {anniversary_date}, is more than 20 days away from the regular payment date, {zero_date + _MONTH}')
-
     for i, x in enumerate(insertions):
         if x.date <= zero_date:
             raise ValueError(f'"insertions[{i}].date", {x.date}, must succeed "zero_date", {zero_date}')
@@ -2993,9 +2984,6 @@ def preprocess_livre(
 
         elif y.date > (due := amortizations[-1].date):
             raise ValueError(f'"insertions[{i}].date", {y.date}, succeeds the last regular payment date, {due}')
-
-    if abs((amortizations[1].date - (amortizations[0].date + _MONTH)).days) > 20:
-        raise ValueError(f'the first payment date, {amortizations[1].date}, is more than 20 days away from the regular payment date, {amortizations[0].date + _MONTH}')
 
     if len(set([z.date for z in amortizations])) != len(amortizations):
         raise ValueError('amortization dates must be unique.')

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class CustomInstallScripts(InstallScripts):
 
 setup(
     name='fincore',
-    version='4.11.0',
+    version='4.12.0',
     description='A financial core library',
     author='Rafael Viotti',
     author_email='viotti@inco.vc',

--- a/tests/test_fincore.py
+++ b/tests/test_fincore.py
@@ -182,28 +182,6 @@ def test_wont_create_sched_1():
 
         next(fincore.build_bullet(**kwa))
 
-    with pytest.raises(ValueError, match='the "anniversary_date", 2023-01-22, is more than 20 days away from the regular payment date, 2023-01-01'):
-        kwa = {}
-
-        kwa['principal'] = decimal.Decimal('120000')
-        kwa['apy'] = decimal.Decimal('12')
-        kwa['zero_date'] = datetime.date(2022, 1, 1)
-        kwa['anniversary_date'] = datetime.date(2023, 1, 22)
-        kwa['term'] = 12
-
-        next(fincore.build_bullet(**kwa))
-
-    with pytest.raises(ValueError, match='the "anniversary_date", 2022-12-10, is more than 20 days away from the regular payment date, 2023-01-01'):
-        kwa = {}
-
-        kwa['principal'] = decimal.Decimal('120000')
-        kwa['apy'] = decimal.Decimal('12')
-        kwa['zero_date'] = datetime.date(2022, 1, 1)
-        kwa['anniversary_date'] = datetime.date(2022, 12, 10)
-        kwa['term'] = 12
-
-        next(fincore.build_bullet(**kwa))
-
     with pytest.raises(ValueError, match='the "anniversary_date", 2022-01-01, must be greater than "zero_date", 2022-01-01'):
         kwa = {}
 
@@ -291,28 +269,6 @@ def test_wont_create_sched_2():
 
         next(fincore.build_jm(**kwa))
 
-    with pytest.raises(ValueError, match='the "anniversary_date", 2021-08-22, is more than 20 days away from the regular payment date, 2021-08-01'):
-        kwa = {}
-
-        kwa['principal'] = decimal.Decimal('222000')
-        kwa['apy'] = decimal.Decimal('13.5')
-        kwa['zero_date'] = datetime.date(2021, 7, 1)
-        kwa['anniversary_date'] = datetime.date(2021, 8, 22)
-        kwa['term'] = 9
-
-        next(fincore.build_jm(**kwa))
-
-    with pytest.raises(ValueError, match='the "anniversary_date", 2021-07-10, is more than 20 days away from the regular payment date, 2021-08-01'):
-        kwa = {}
-
-        kwa['principal'] = decimal.Decimal('222000')
-        kwa['apy'] = decimal.Decimal('13.5')
-        kwa['zero_date'] = datetime.date(2021, 7, 1)
-        kwa['anniversary_date'] = datetime.date(2021, 7, 10)
-        kwa['term'] = 9
-
-        next(fincore.build_jm(**kwa))
-
     with pytest.raises(ValueError, match='the "anniversary_date", 2021-07-01, must be greater than "zero_date", 2021-07-01'):
         kwa = {}
 
@@ -386,28 +342,6 @@ def test_wont_create_sched_3():
         kwa['anniversary_date'] = datetime.date(2022, 2, 5)
         kwa['term'] = 12
         kwa['insertions'] = [fincore.Amortization.Bare(date=datetime.date(2023, 1, 10), value=decimal.Decimal(5000))]
-
-        next(fincore.build_price(**kwa))
-
-    with pytest.raises(ValueError, match='the "anniversary_date", 2021-08-22, is more than 20 days away from the regular payment date, 2021-08-01'):
-        kwa = {}
-
-        kwa['principal'] = decimal.Decimal('222000')
-        kwa['apy'] = decimal.Decimal('13.5')
-        kwa['zero_date'] = datetime.date(2021, 7, 1)
-        kwa['anniversary_date'] = datetime.date(2021, 8, 22)
-        kwa['term'] = 9
-
-        next(fincore.build_price(**kwa))
-
-    with pytest.raises(ValueError, match='the "anniversary_date", 2021-07-10, is more than 20 days away from the regular payment date, 2021-08-01'):
-        kwa = {}
-
-        kwa['principal'] = decimal.Decimal('222000')
-        kwa['apy'] = decimal.Decimal('13.5')
-        kwa['zero_date'] = datetime.date(2021, 7, 1)
-        kwa['anniversary_date'] = datetime.date(2021, 7, 10)
-        kwa['term'] = 9
 
         next(fincore.build_price(**kwa))
 
@@ -524,36 +458,6 @@ def test_wont_create_sched_4():
         tab1.append(fincore.Amortization(date=datetime.date(2020, 4, 15), amortization_ratio=decimal.Decimal('0.25')))
         tab1.append(fincore.Amortization(date=datetime.date(2020, 4, 15), amortization_ratio=decimal.Decimal('0.25')))
         tab1.append(fincore.Amortization(date=datetime.date(2020, 5, 15), amortization_ratio=decimal.Decimal('0.25')))
-
-        next(fincore.build(**kwa))
-
-    with pytest.raises(ValueError, match='the first payment date, 2020-05-06, is more than 20 days away from the regular payment date, 2020-04-15'):
-        kwa = {}
-
-        kwa['principal'] = decimal.Decimal('222000')
-        kwa['apy'] = decimal.Decimal('13.5')
-        kwa['amortizations'] = tab1 = []
-
-        # Monta a tabela de amortizações.
-        tab1.append(fincore.Amortization(date=datetime.date(2020, 3, 15), amortization_ratio=decimal.Decimal('0.25')))
-        tab1.append(fincore.Amortization(date=datetime.date(2020, 5, 6), amortization_ratio=decimal.Decimal('0.25')))
-        tab1.append(fincore.Amortization(date=datetime.date(2020, 6, 6), amortization_ratio=decimal.Decimal('0.25')))
-        tab1.append(fincore.Amortization(date=datetime.date(2020, 7, 6), amortization_ratio=decimal.Decimal('0.25')))
-
-        next(fincore.build(**kwa))
-
-    with pytest.raises(ValueError, match='the first payment date, 2020-03-07, is more than 20 days away from the regular payment date, 2020-03-28'):
-        kwa = {}
-
-        kwa['principal'] = decimal.Decimal('222000')
-        kwa['apy'] = decimal.Decimal('13.5')
-        kwa['amortizations'] = tab1 = []
-
-        # Monta a tabela de amortizações.
-        tab1.append(fincore.Amortization(date=datetime.date(2020, 2, 28), amortization_ratio=decimal.Decimal('0.25')))
-        tab1.append(fincore.Amortization(date=datetime.date(2020, 3, 7), amortization_ratio=decimal.Decimal('0.25')))
-        tab1.append(fincore.Amortization(date=datetime.date(2020, 4, 21), amortization_ratio=decimal.Decimal('0.25')))
-        tab1.append(fincore.Amortization(date=datetime.date(2020, 5, 21), amortization_ratio=decimal.Decimal('0.25')))
 
         next(fincore.build(**kwa))
 


### PR DESCRIPTION
The anniversary date can be more than 20 days away from the first regular payment date.