### PR TITLE
chore: reduce log level for 365-day capitalisation warning to INFO

### DIFF
--- a/fincore.py
+++ b/fincore.py
@@ -1068,10 +1068,10 @@ class IndexStorageBackend:
             fac = fac * (_1 + max(x.value, _0) / decimal.Decimal(100)) ** exp
 
         if not mem and period == 1:
-            _LOG.warning(f'no IPCA indexes found for month {ini.year:04d}-{ini.month:02d} (base date is {base}, period is {period}, shift is {shift}, ratio is {ratio})')
+            _LOG.info(f'no IPCA indexes found for month {ini.year:04d}-{ini.month:02d} (base date is {base}, period is {period}, shift is {shift}, ratio is {ratio})')
 
         elif not mem:
-            _LOG.warning(f'no IPCA indexes found between {ini.year:04d}-{ini.month:02d} and {end.year:04d}-{end.month:02d} (base date is {base}, period is {period}, shift is {shift}, ratio is {ratio})')
+            _LOG.info(f'no IPCA indexes found between {ini.year:04d}-{ini.month:02d} and {end.year:04d}-{end.month:02d} (base date is {base}, period is {period}, shift is {shift}, ratio is {ratio})')
 
         return types.SimpleNamespace(value=fac, mem=mem)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class CustomInstallScripts(InstallScripts):
 
 setup(
     name='fincore',
-    version='4.12.0',
+    version='4.12.1',
     description='A financial core library',
     author='Rafael Viotti',
     author_email='viotti@inco.vc',


### PR DESCRIPTION
This message is informational rather than a warning since 365-day capitalisation is still supported for legacy Bullet operations.

Slack thread: https://inco1.slack.com/archives/C038UBQG44E/p1772555048558409?thread_ts=1772550799.512419&cid=C038UBQG44E

https://claude.ai/code/session_01B9KJpZ6LB3B2J1did983D9